### PR TITLE
Fix __all__ comma and ensure newline

### DIFF
--- a/cortopy/__init__.py
+++ b/cortopy/__init__.py
@@ -1,5 +1,5 @@
 """
-# CORTO - cortopy 
+# CORTO - cortopy
 
 https://github.com/MattiaPugliatti/corto
 
@@ -18,7 +18,7 @@ __all__ = (
     "Sun",
     "State",
     "Environment",
-    "Rendering"
+    "Rendering",
     "PostPro",
     "Shading",
     "Compositing"
@@ -33,4 +33,4 @@ from ._Environment import Environment
 from ._Rendering import Rendering
 from ._Shading import Shading
 from ._Compositing import Compositing
-from ._Utils import Utils 
+from ._Utils import Utils


### PR DESCRIPTION
## Summary
- add missing comma after `"Rendering"`
- ensure `cortopy/__init__.py` ends with a newline

## Testing
- `python3 -m py_compile cortopy/__init__.py`

------
https://chatgpt.com/codex/tasks/task_e_684619d2ff8c832095b1746c34f56071